### PR TITLE
Move each command to its own module/file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,148 +1,20 @@
-use std::fs;
-use std::path::Path;
-
-use chrono::NaiveDate;
 use serenity::client::Client;
-use serenity::framework::standard::macros::{command, group};
-use serenity::framework::standard::{CommandResult, StandardFramework};
-use serenity::http::AttachmentType;
-use serenity::model::channel::Message;
-use serenity::model::id::ChannelId;
-use serenity::prelude::{Context, EventHandler};
-use serenity::utils::Colour;
+use serenity::framework::standard::macros::group;
+use serenity::framework::standard::StandardFramework;
+use serenity::prelude::EventHandler;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+mod minutes;
+mod poll;
+mod resource;
+
+use minutes::MINUTES_COMMAND;
+use poll::POLL_COMMAND;
+use resource::RESOURCE_COMMAND;
+
 /// The prefix for commands such as `!poll`.
 const PREFIX: &str = "!";
-/// Unicode encodings for the emojis 1-9 to react with on poll messages.
-const REACTIONS: [&str; 9] = [
-    "\u{31}\u{FE0F}\u{20E3}",
-    "\u{32}\u{FE0F}\u{20E3}",
-    "\u{33}\u{FE0F}\u{20E3}",
-    "\u{34}\u{FE0F}\u{20E3}",
-    "\u{35}\u{FE0F}\u{20E3}",
-    "\u{36}\u{FE0F}\u{20E3}",
-    "\u{37}\u{FE0F}\u{20E3}",
-    "\u{38}\u{FE0F}\u{20E3}",
-    "\u{39}\u{FE0F}\u{20E3}",
-];
-
-/// Creates a poll message and sends it to the user.
-///
-/// Given a command such as `!poll Name Option1 Option2 Option3`, this will be called with the
-/// arguments `[Name, Option1, Option2, Option3]`, allowing the bot to format the poll and send it.
-///
-/// Poll messages use an embedded message for nicer formatting, and add reactions for each option
-/// that the poll provides.
-#[command]
-fn poll(context: &mut Context, msg: &Message) -> CommandResult {
-    let args: Vec<&str> = msg.content.split(' ').skip(1).collect();
-    let (title, options) = args
-        .split_first()
-        .ok_or("Invalid number of arguments to !poll")?;
-
-    let formatted_options = options
-        .iter()
-        .zip(REACTIONS.iter())
-        .map(|(o, r)| format!("{} `{}`", r, o))
-        .collect::<Vec<String>>()
-        .join("\n");
-
-    let sent_message = msg.channel_id.send_message(&context, |m| {
-        m.embed(|e| {
-            e.title(title.to_uppercase())
-                .description(formatted_options)
-                .colour(Colour::from_rgb(0, 106, 176))
-        })
-    })?;
-
-    for reaction in REACTIONS.iter().take(options.len()) {
-        sent_message.react(&context, *reaction)?;
-    }
-
-    Ok(())
-}
-
-/// Returns all messages from a given day in a given channel.
-///
-/// Given the command `!minutes <date>`, where <date> follows the format d/m/Y, this handler will
-/// collect the messages sent on that date and format them into a structured Markdown document,
-/// before sending it back to the caller.
-#[command]
-fn minutes(context: &mut Context, msg: &Message) -> CommandResult {
-    let args: Vec<&str> = msg.content.split(' ').skip(1).collect();
-    let day: NaiveDate = NaiveDate::parse_from_str(
-        args.get(0).ok_or("Insufficient arguments provided.")?,
-        "%d/%m/%Y",
-    )?;
-    let messages: Vec<Message> = msg.channel_id.messages(&context, |b| b.limit(1000))?;
-
-    let relevant: String = messages
-        .iter()
-        .filter(|x| x.timestamp.naive_local().date() == day)
-        .map(|x| {
-            format!(
-                "\n{}\t**{}**:\t{}\n",
-                x.timestamp.time().format("%H:%M").to_string(),
-                x.author.name.replace("*", ""),
-                x.content
-            )
-        })
-        .rev()
-        .collect::<String>();
-
-    let formatted_minutes = format!("# Meeting minutes for {} \n{}", day, relevant);
-    let filename = format!("minutes-{}.md", day.format("%Y-%m-%d"));
-    let path = Path::new(&filename);
-
-    // Write the formatted minutes to the file
-    fs::write(&path, formatted_minutes)?;
-
-    msg.channel_id
-        .send_files(&context, vec![AttachmentType::Path(&path)], |m| {
-            m.content(format!("Meeting minutes for {}", day))
-        })?;
-
-    // Delete the file once it has been sent
-    fs::remove_file(&path)?;
-
-    Ok(())
-}
-
-/// Forwards a message to the `#resources` channel.
-///
-/// Given the command `!resource <message>`, this handler will forward <message> to the
-/// `#resources` channel with a short preamble.
-#[command]
-fn resource(context: &mut Context, msg: &Message) -> CommandResult {
-    let first_space = msg
-        .content
-        .chars()
-        .position(|c| c == ' ')
-        .ok_or("Command has no arguments")?;
-
-    let resource = &msg.content[first_space + 1..];
-
-    let resources_channel: ChannelId = msg
-        .guild_id
-        .ok_or("Message occurred outside of a Guild environment.")?
-        .channels(&context)?
-        .values()
-        .find(|x| x.name == "resources")
-        .ok_or("Failed to find a channel with the name: 'resources'")?
-        .id;
-
-    resources_channel.send_message(&context, |m| {
-        m.content(format!(
-            "**{}** submitted the following resource:\n> {}",
-            msg.author.name.replace("*", ""),
-            resource
-        ))
-    })?;
-
-    Ok(())
-}
 
 #[group]
 #[commands(minutes, poll, resource)]

--- a/src/minutes.rs
+++ b/src/minutes.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::path::Path;
+
+use chrono::NaiveDate;
+
+use serenity::client::Context;
+use serenity::framework::standard::macros::command;
+use serenity::framework::standard::CommandResult;
+use serenity::http::AttachmentType;
+use serenity::model::channel::Message;
+
+/// Returns all messages from a given day in a given channel.
+///
+/// Given the command `!minutes <date>`, where <date> follows the format d/m/Y, this handler will
+/// collect the messages sent on that date and format them into a structured Markdown document,
+/// before sending it back to the caller.
+#[command]
+fn minutes(context: &mut Context, msg: &Message) -> CommandResult {
+    let args: Vec<&str> = msg.content.split(' ').skip(1).collect();
+    let day: NaiveDate = NaiveDate::parse_from_str(
+        args.get(0).ok_or("Insufficient arguments provided.")?,
+        "%d/%m/%Y",
+    )?;
+    let messages: Vec<Message> = msg.channel_id.messages(&context, |b| b.limit(1000))?;
+
+    let relevant: String = messages
+        .iter()
+        .filter(|x| x.timestamp.naive_local().date() == day)
+        .map(|x| {
+            format!(
+                "\n{}\t**{}**:\t{}\n",
+                x.timestamp.time().format("%H:%M").to_string(),
+                x.author.name.replace("*", ""),
+                x.content
+            )
+        })
+        .rev()
+        .collect::<String>();
+
+    let formatted_minutes = format!("# Meeting minutes for {} \n{}", day, relevant);
+    let filename = format!("minutes-{}.md", day.format("%Y-%m-%d"));
+    let path = Path::new(&filename);
+
+    // Write the formatted minutes to the file
+    fs::write(&path, formatted_minutes)?;
+
+    msg.channel_id
+        .send_files(&context, vec![AttachmentType::Path(&path)], |m| {
+            m.content(format!("Meeting minutes for {}", day))
+        })?;
+
+    // Delete the file once it has been sent
+    fs::remove_file(&path)?;
+
+    Ok(())
+}

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,0 +1,54 @@
+use serenity::client::Context;
+use serenity::framework::standard::macros::command;
+use serenity::framework::standard::CommandResult;
+use serenity::model::channel::Message;
+use serenity::utils::Colour;
+
+/// Unicode encodings for the emojis 1-9 to react with on poll messages.
+const REACTIONS: [&str; 9] = [
+    "\u{31}\u{FE0F}\u{20E3}",
+    "\u{32}\u{FE0F}\u{20E3}",
+    "\u{33}\u{FE0F}\u{20E3}",
+    "\u{34}\u{FE0F}\u{20E3}",
+    "\u{35}\u{FE0F}\u{20E3}",
+    "\u{36}\u{FE0F}\u{20E3}",
+    "\u{37}\u{FE0F}\u{20E3}",
+    "\u{38}\u{FE0F}\u{20E3}",
+    "\u{39}\u{FE0F}\u{20E3}",
+];
+
+/// Creates a poll message and sends it to the user.
+///
+/// Given a command such as `!poll Name Option1 Option2 Option3`, this will be called with the
+/// arguments `[Name, Option1, Option2, Option3]`, allowing the bot to format the poll and send it.
+///
+/// Poll messages use an embedded message for nicer formatting, and add reactions for each option
+/// that the poll provides.
+#[command]
+pub fn poll(context: &mut Context, msg: &Message) -> CommandResult {
+    let args: Vec<&str> = msg.content.split(' ').skip(1).collect();
+    let (title, options) = args
+        .split_first()
+        .ok_or("Invalid number of arguments to !poll")?;
+
+    let formatted_options = options
+        .iter()
+        .zip(REACTIONS.iter())
+        .map(|(o, r)| format!("{} `{}`", r, o))
+        .collect::<Vec<String>>()
+        .join("\n");
+
+    let sent_message = msg.channel_id.send_message(&context, |m| {
+        m.embed(|e| {
+            e.title(title.to_uppercase())
+                .description(formatted_options)
+                .colour(Colour::from_rgb(0, 106, 176))
+        })
+    })?;
+
+    for reaction in REACTIONS.iter().take(options.len()) {
+        sent_message.react(&context, *reaction)?;
+    }
+
+    Ok(())
+}

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,0 +1,39 @@
+use serenity::client::Context;
+use serenity::framework::standard::macros::command;
+use serenity::framework::standard::CommandResult;
+use serenity::model::channel::Message;
+use serenity::model::id::ChannelId;
+
+/// Forwards a message to the `#resources` channel.
+///
+/// Given the command `!resource <message>`, this handler will forward <message> to the
+/// `#resources` channel with a short preamble.
+#[command]
+fn resource(context: &mut Context, msg: &Message) -> CommandResult {
+    let first_space = msg
+        .content
+        .chars()
+        .position(|c| c == ' ')
+        .ok_or("Command has no arguments")?;
+
+    let resource = &msg.content[first_space + 1..];
+
+    let resources_channel: ChannelId = msg
+        .guild_id
+        .ok_or("Message occurred outside of a Guild environment.")?
+        .channels(&context)?
+        .values()
+        .find(|x| x.name == "resources")
+        .ok_or("Failed to find a channel with the name: 'resources'")?
+        .id;
+
+    resources_channel.send_message(&context, |m| {
+        m.content(format!(
+            "**{}** submitted the following resource:\n> {}",
+            msg.author.name.replace("*", ""),
+            resource
+        ))
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
Move each command that is currently defined into its own file/module that can
be accessed with `mod <command>`. This allows minimal imports for each file and
allows each file to be smaller and more self-contained.