### PR TITLE
Upgrade the run.sh script with better logging

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,7 @@ while true; do
 
 	# Build a release binary and start the bot in the background
 	/root/.cargo/bin/cargo build --release
-	/root/.cargo/bin/cargo run --release >> $PYTHIA_LOG &
+	/root/.cargo/bin/cargo run --release >> $PYTHIA_LOG 2>&1 &
 
 	# Store the process identifier of the bot
 	pid=$!


### PR DESCRIPTION
Upgrade the run.sh script to allow it to log better. Logs are stored in
`/root/.logs` and the activities of both run.sh and Pythia itself are logged
into files with timestamps.

Implement a shutdown command so that changes to run.sh will cause a server
restart and allow the new configuration to be used.