### PR TITLE
Help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,38 @@ It is named after [Pythia](https://en.wikipedia.org/wiki/Pythia), who was the
 functionality such as poll creation, meeting minute recording, agenda
 management and resource cataloguing.
 
+## Usage
+
+Pythia uses the `!` command prefix and will not respond to any other messages.
+
+`usage: !<command> [<args>]`
+
+Pythia can perform many tasks to assist project management in a Discord server:
+
+ - Manage the **agenda** of a future meeting:
+
+		!agenda add <item>    add an <item> to the current agenda
+		!agenda show          send the agenda in the 'meetings' channel
+		!agenda export        export the agenda as a markdown file
+		!agenda clear         clear the agenda
+
+ - Collate meeting **minutes** for a given day:
+
+        !minutes <date>       export the messages sent in the 'meetings' channel on
+                              the date <date> (D/M/Y) as a formatted markdown file
+
+ - Create a **poll** message:
+
+        !poll <title> <args>  creates a poll message with title <title> and options
+                              <args>, up to a maximum of 10 arguments
+
+ - Record a useful **resource** for future reference:
+
+        !resource <item>      records the <item> in the 'resources' channel to make
+                              sure it doesn't get lost in discussion
+
+This information can also be retrieved by sending the `!help` command to Pythia
+
 ## Development
 
 The bot can be built by cloning the repository and building it using `cargo

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Pythia can perform many tasks to assist project management in a Discord server:
         !resource <item>      records the <item> in the 'resources' channel to make
                               sure it doesn't get lost in discussion
 
-This information can also be retrieved by sending the `!help` command to Pythia
+This information can also be retrieved by sending the `!help` command to Pythia.
 
 ## Development
 
@@ -48,7 +48,7 @@ build`, which will install all the required dependencies.
 
 It expects the Discord token to be found in a file called `token.env`, which
 should be in the root directory of the project. This should contain a single
-line in the form `token=...`
+line in the form `token=<token>`.
 
 ### Discord Setup
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,0 +1,42 @@
+use serenity::client::Context;
+use serenity::framework::standard::macros::command;
+use serenity::framework::standard::CommandResult;
+use serenity::model::channel::Message;
+
+const DOCUMENTATION: &str = " \
+My name is **Pythia**! I'm here to help you manage your project in Discord!
+`usage: !<command> [<args>]`
+
+Manage the **agenda** of a future meeting:
+```
+!agenda add <item>    add an <item> to the current agenda
+!agenda show          send the agenda in the 'meetings' channel
+!agenda export        export the agenda as a markdown file
+!agenda clear         clear the agenda
+```
+Collate meeting **minutes** for a given day:
+```
+!minutes <date>       export the messages sent in the 'meetings' channel on
+                      the date <date> (D/M/Y) as a formatted markdown file
+```
+Create a **poll** message:
+```
+!poll <title> <args>  creates a poll message with title <title> and options
+                      <args>, up to a maximum of 10 arguments
+```
+Record a useful **resource** for future reference:
+```
+!resource <item>      records the <item> in the 'resources' channel to make
+                      sure it doesn't get lost in discussion
+```";
+
+/// Given the command `!help`, this handler will send a useful, formatted
+/// help message explaining Pythia commands.
+#[command]
+fn help(context: &mut Context, msg: &Message) -> CommandResult {
+    msg.channel_id.send_message(&context, |m| {
+        m.content(DOCUMENTATION)
+    })?;
+
+    Ok(())
+}

--- a/src/help.rs
+++ b/src/help.rs
@@ -34,9 +34,8 @@ Record a useful **resource** for future reference:
 /// help message explaining Pythia commands.
 #[command]
 fn help(context: &mut Context, msg: &Message) -> CommandResult {
-    msg.channel_id.send_message(&context, |m| {
-        m.content(DOCUMENTATION)
-    })?;
+    msg.channel_id
+        .send_message(&context, |m| m.content(DOCUMENTATION))?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,14 @@ use serenity::prelude::EventHandler;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-mod help;
 mod agenda;
+mod help;
 mod minutes;
 mod poll;
 mod resource;
 
-use help::HELP_COMMAND;
 use agenda::AGENDA_COMMAND;
+use help::HELP_COMMAND;
 use minutes::MINUTES_COMMAND;
 use poll::POLL_COMMAND;
 use resource::RESOURCE_COMMAND;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,13 @@ use serenity::prelude::EventHandler;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+mod help;
 mod agenda;
 mod minutes;
 mod poll;
 mod resource;
 
+use help::HELP_COMMAND;
 use agenda::AGENDA_COMMAND;
 use minutes::MINUTES_COMMAND;
 use poll::POLL_COMMAND;
@@ -19,7 +21,7 @@ use resource::RESOURCE_COMMAND;
 const PREFIX: &str = "!";
 
 #[group]
-#[commands(minutes, poll, resource, agenda)]
+#[commands(help, minutes, poll, resource, agenda)]
 struct General;
 struct Handler;
 


### PR DESCRIPTION
### Overview

This PR adds the long awaited `!help` command endpoint to the Pythia bot. The format of the `!help` response is modelled on the structure of traditional help outputs for shell commands, but has also been modernised to suit a markdown formatted interface. This information has also been added to the `README.md` file for documentation purposes.

### Functionality

This PR implements the command `help(context: &mut Context, msg: &Message)` in the file `src/help.rs` to facilitate response to help commands. The `README.md` is also updated with detailed instructions on how to use Pythia's command endpoints.