### PR TITLE
Add better argument parsing

### DIFF
--- a/src/arglexer.rs
+++ b/src/arglexer.rs
@@ -1,0 +1,92 @@
+use std::str::CharIndices;
+
+fn lex_word<'a, 'b>(message: &'a str, start: usize, chars: &'b mut CharIndices) -> &'a str {
+    let count = chars
+        .position(|(_, c)| !c.is_alphanumeric())
+        .unwrap_or_else(|| message.len() - start - 1)
+        + 1;
+
+    &message[start..start + count]
+}
+
+fn lex_sentence<'a, 'b>(message: &'a str, start: usize, chars: &'b mut CharIndices) -> &'a str {
+    let count = chars
+        .position(|(_, c)| c == '"')
+        .unwrap_or_else(|| message.len() - start - 1)
+        + 1;
+
+    &message[start + 1..start + count]
+}
+
+pub fn lex_args(message: &str) -> Vec<&str> {
+    // Ignore the first word
+    let first_space = message.find(' ').unwrap();
+    let arguments = message.split_at(first_space + 1).1;
+
+    // Parse the arguments using the characters
+    let mut chars = arguments.char_indices();
+    let mut args = Vec::new();
+
+    while let Some((i, c)) = chars.next() {
+        if c.is_alphanumeric() {
+            let word = lex_word(arguments, i, &mut chars);
+            args.push(word);
+        } else if c == '"' {
+            let sentence = lex_sentence(arguments, i, &mut chars);
+            args.push(sentence);
+        }
+    }
+
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_lexing() {
+        let message = r#"!poll title arg1 arg2"#;
+        let args = lex_args(message);
+        let expected = vec!["title", "arg1", "arg2"];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn quotation_marks() {
+        let message = r#"!poll title "arg1" arg2"#;
+        let args = lex_args(message);
+        let expected = vec!["title", "arg1", "arg2"];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn multi_word_quotations() {
+        let message = r#"!poll title "arg1 arg2""#;
+        let args = lex_args(message);
+        let expected = vec!["title", "arg1 arg2"];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn multiple_sentences() {
+        let message = r#"!poll "longer title" "arg1 arg2""#;
+        let args = lex_args(message);
+        let expected = vec!["longer title", "arg1 arg2"];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    #[should_panic]
+    fn mismatched_quotations() {
+        let message = r#"!poll "longer title "arg1 arg2""#;
+        let args = lex_args(message);
+        let expected = vec!["longer title", "arg1 arg2"];
+
+        assert_eq!(args, expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,24 @@
+use serenity::framework::standard::macros::group;
+use serenity::prelude::EventHandler;
+
+mod agenda;
+mod help;
+mod minutes;
+mod poll;
+mod resource;
+
+use agenda::AGENDA_COMMAND;
+use help::HELP_COMMAND;
+use minutes::MINUTES_COMMAND;
+use poll::POLL_COMMAND;
+use resource::RESOURCE_COMMAND;
+
+/// The prefix for commands such as `!poll`.
+pub const PREFIX: &str = "!";
+
+#[group]
+#[commands(help, minutes, poll, resource, agenda)]
+pub struct General;
+pub struct Handler;
+
+impl EventHandler for Handler {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use serenity::framework::standard::macros::group;
 use serenity::prelude::EventHandler;
 
 mod agenda;
+mod arglexer;
 mod help;
 mod minutes;
 mod poll;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,7 @@
 use serenity::client::Client;
-use serenity::framework::standard::macros::group;
 use serenity::framework::standard::StandardFramework;
-use serenity::prelude::EventHandler;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
-
-mod agenda;
-mod help;
-mod minutes;
-mod poll;
-mod resource;
-
-use agenda::AGENDA_COMMAND;
-use help::HELP_COMMAND;
-use minutes::MINUTES_COMMAND;
-use poll::POLL_COMMAND;
-use resource::RESOURCE_COMMAND;
-
-/// The prefix for commands such as `!poll`.
-const PREFIX: &str = "!";
-
-#[group]
-#[commands(help, minutes, poll, resource, agenda)]
-struct General;
-struct Handler;
-
-impl EventHandler for Handler {}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -40,11 +16,11 @@ async fn main() -> Result<()> {
 
     // Start the client with the token and the handler struct
     let mut client = Client::builder(token)
-        .event_handler(Handler)
+        .event_handler(pythia::Handler)
         .framework(
             StandardFramework::new()
-                .configure(|c| c.prefix(PREFIX))
-                .group(&GENERAL_GROUP),
+                .configure(|c| c.prefix(pythia::PREFIX))
+                .group(&pythia::GENERAL_GROUP),
         )
         .await?;
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -6,6 +6,8 @@ use serenity::framework::standard::CommandResult;
 use serenity::model::channel::{Message, ReactionType};
 use serenity::utils::Colour;
 
+use crate::arglexer;
+
 /// Unicode encodings for the emojis 1-9 to react with on poll messages.
 const REACTIONS: [&str; 9] = [
     "\u{31}\u{FE0F}\u{20E3}",
@@ -28,7 +30,7 @@ const REACTIONS: [&str; 9] = [
 /// that the poll provides.
 #[command]
 async fn poll(context: &Context, msg: &Message) -> CommandResult {
-    let args: Vec<&str> = msg.content.split(' ').skip(1).collect();
+    let args = arglexer::lex_args(&msg.content);
 
     log::info!("Executing 'poll' command with args: {:?}", args);
 


### PR DESCRIPTION
Add better argument parsing, only to `!poll` for the moment. This allows
things like `!poll "Longer Title Name" A B "Longer Option"` to be
interpreted as expected.

Fixes #19.