### PR TITLE
deps: swap to `tracing` from `log`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,17 +42,6 @@ dependencies = [
  "tokio-rustls 0.22.0",
  "tungstenite",
  "webpki-roots 0.20.0",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -130,17 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "command_attr"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,16 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "fern"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
-dependencies = [
- "colored",
- "log",
 ]
 
 [[package]]
@@ -501,6 +478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,12 +655,12 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dotenv",
- "fern",
- "log",
  "serde",
  "serde_json",
  "serenity",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -726,6 +712,30 @@ checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "reqwest"
@@ -925,10 +935,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"
@@ -961,6 +986,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1089,6 +1123,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
+dependencies = [
+ "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,11 @@ edition = "2018"
 dotenv = "0.15.0"
 serenity = "0.10.9"
 chrono = "0.4.19"
-log = "0.4.14"
 serde_json = "1.0.73"
 serde = "1.0.132"
+tracing = "0.1.29"
+tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 
 [dependencies.tokio]
 version = "1.15.0"
 features = ["macros", "rt-multi-thread"]
-
-[dependencies.fern]
-version = "0.6.0"
-features = ["colored"]

--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -75,7 +75,7 @@ const FAILURE: char = '❌';
 async fn agenda(context: &Context, msg: &Message) -> CommandResult {
     // Collect the sub-command and arguments
     let args: Vec<&str> = msg.content.split(' ').skip(1).collect();
-    log::info!("Executing 'agenda' command with args: {:?}", args);
+    tracing::info!(?args, "Executing an 'agenda' command");
 
     match args[0] {
         "add" | "append" | "push" => {
@@ -144,7 +144,7 @@ async fn agenda(context: &Context, msg: &Message) -> CommandResult {
         }
         "clear" | "new" => {
             // Log the event
-            log::info!("{} cleared the current agenda", msg.author.name);
+            tracing::info!(user = %msg.author.name, "Cleared the agenda");
 
             // Replace the agenda with a default copy
             Agenda::new().save("agenda.json")?;
@@ -155,11 +155,7 @@ async fn agenda(context: &Context, msg: &Message) -> CommandResult {
         _ => {
             // Relay the failure of the sub-command to the user
             msg.react(&context, FAILURE).await?;
-            log::info!(
-                "{} sent an unrecognised sub-command {} for 'agenda'",
-                msg.author.name,
-                args[0]
-            );
+            tracing::debug!(user = %msg.author.name, command = %args[0], "Unrecognised sub-command for 'agenda'");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,53 +1,29 @@
-use fern::colors::{Color, ColoredLevelConfig};
 use serenity::client::Client;
 use serenity::framework::standard::StandardFramework;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 /// Sets up the logging for the application.
-///
-/// Initialises a new instance of a [`fern`] logger, which displays the time and some coloured
-/// output based on the level of the message. It also suppresses output from libraries unless they
-/// are warnings or errors, and enables all log levels for the current binary.
-pub fn setup_logger(lvl_for: &'static str) {
-    let colours_line = ColoredLevelConfig::new()
-        .error(Color::Red)
-        .warn(Color::Yellow)
-        .info(Color::Green)
-        .debug(Color::Blue)
-        .trace(Color::BrightBlack);
+pub fn setup() {
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "info,pythia=debug")
+    }
 
-    fern::Dispatch::new()
-        .format(move |out, message, record| {
-            out.finish(format_args!(
-                "{colours_line}[{date}][{target}][{level}]\x1B[0m {message}",
-                colours_line = format_args!(
-                    "\x1B[{}m",
-                    colours_line.get_color(&record.level()).to_fg_str()
-                ),
-                date = chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                target = record.target(),
-                level = record.level(),
-                message = message,
-            ));
-        })
-        .level(log::LevelFilter::Warn)
-        .level_for(lvl_for, log::LevelFilter::Trace)
-        .chain(std::io::stdout())
-        .apply()
-        .expect("Failed to initialise the logger");
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Configure the logger
-    setup_logger("pythia");
+    setup();
 
     // Read the token file into environment variables
     dotenv::from_filename("token.env").ok();
     let token = std::env::var("token")?;
 
-    log::info!("Initialised Pythia with a token, beginning execution");
+    tracing::info!("Initialised Pythia with a token, beginning execution");
 
     // Start the client with the token and the handler struct
     let mut client = Client::builder(token)

--- a/src/minutes.rs
+++ b/src/minutes.rs
@@ -17,16 +17,16 @@ use serenity::model::channel::Message;
 #[command]
 async fn minutes(context: &Context, msg: &Message) -> CommandResult {
     let args: Vec<&str> = msg.content.split(' ').skip(1).collect();
-    log::info!("Executing 'minutes' command with args: {:?}", args);
+    tracing::info!(?args, "Executing a 'minutes' command");
 
     let day: NaiveDate = NaiveDate::parse_from_str(
         args.get(0).ok_or("Insufficient arguments provided.")?,
         "%d/%m/%Y",
     )?;
-    log::info!("Date was interpreted as: {}", day);
+    tracing::info!(?day, "Parsed a date from the message");
 
     let messages: Vec<Message> = msg.channel_id.messages(&context, |b| b.limit(1000)).await?;
-    log::info!("Number of messages pulled from chat: {}", messages.len());
+    tracing::debug!(count = %messages.len(), "Queried some messages from the API");
 
     let relevant: String = messages
         .iter()
@@ -48,7 +48,7 @@ async fn minutes(context: &Context, msg: &Message) -> CommandResult {
 
     // Write the formatted minutes to the file
     fs::write(&path, formatted_minutes)?;
-    log::info!("Wrote the minutes to: {}", &path.display());
+    tracing::debug!(path = %path.display(), "Wrote some minutes to disk");
 
     msg.channel_id
         .send_files(&context, vec![AttachmentType::Path(path)], |m| {
@@ -58,10 +58,7 @@ async fn minutes(context: &Context, msg: &Message) -> CommandResult {
 
     // Delete the file once it has been sent
     fs::remove_file(&path)?;
-    log::info!(
-        "After sending, removed the file from disk: {}",
-        &path.display()
-    );
+    tracing::debug!(path = %path.display(), "Deleted a file from disk after sending it");
 
     Ok(())
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -32,13 +32,13 @@ const REACTIONS: [&str; 9] = [
 async fn poll(context: &Context, msg: &Message) -> CommandResult {
     let args = arglexer::lex_args(&msg.content);
 
-    log::info!("Executing 'poll' command with args: {:?}", args);
+    tracing::info!(?args, "Executing a 'poll' command");
 
     let (title, options) = args
         .split_first()
         .ok_or("Invalid number of arguments to !poll")?;
 
-    log::info!("Poll title: '{}', poll options: {:?}", title, options);
+    tracing::info!(%title, ?options, "Parsed some arguments to the command");
 
     let formatted_options = options
         .iter()
@@ -63,7 +63,7 @@ async fn poll(context: &Context, msg: &Message) -> CommandResult {
         })
         .await?;
 
-    log::info!("Responded with a formatted poll message");
+    tracing::info!("Responded with a formatted poll message");
 
     Ok(())
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -17,7 +17,7 @@ async fn resource(context: &Context, msg: &Message) -> CommandResult {
         .ok_or("Command has no arguments")?;
 
     let resource = &msg.content[first_space + 1..];
-    log::info!("Adding a resource: {}", resource);
+    tracing::info!(resource_link = %resource, "Adding a resource to the channel");
 
     let resources_channel: ChannelId = msg
         .guild_id
@@ -39,7 +39,7 @@ async fn resource(context: &Context, msg: &Message) -> CommandResult {
         })
         .await?;
 
-    log::info!("Added a message in the relevant #resources channel");
+    tracing::info!("Added a message in the relevant #resources channel");
 
     Ok(())
 }


### PR DESCRIPTION
`tracing` provides more structured logging output compared to the `log` library and also has better support for asynchronous runtimes.
