### PR TITLE
infra: optimise builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust:latest AS chef
-RUN cargo install cargo-chef
+FROM lukemathwalker/cargo-chef:latest-rust-latest AS chef
 WORKDIR app
 
 FROM chef AS planner


### PR DESCRIPTION
Use an existing Docker image instead of building `cargo-chef` every time to speed up the release builds.
