### PR TITLE
ci: cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1.2.0
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -30,6 +32,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1.2.0
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -60,6 +64,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1.2.0
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Cache the dependencies when running `test`, `clippy` or `check`.
